### PR TITLE
refactor: Update branding in header and footer for consistency

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,7 +10,7 @@ export default function LandingPage() {
 			{/* Hero Section */}
 			<section className="text-center">
 				<h1 className="text-5xl font-extrabold">
-					Welcome to JT Dev Studio
+					Welcome to my Dev Studio
 					<div className="animate-flareSpark contents">
 						<Image
 							src="https://torresjdev.github.io/Nextjs-Asset-Host/assets/gif/anime/fire-burn-fabio-nikolaus.gif"

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -143,8 +143,8 @@ const Footer = () => {
 			{/* Footer Bottom */}
 			<div className="text-center text-[#C0C0C0]-500 mt-3">
 				<p>
-					Complete - Full Stack Software Developer: Walkthrough Guide <br></br>{" "}
-					&copy; {new Date().getFullYear()} Jesus Torres. All rights reserved.
+					&nbsp; &copy; {new Date().getFullYear()} Jesus Torres. All rights
+					reserved.
 				</p>
 			</div>
 		</footer>

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -15,7 +15,7 @@ export default function Navigation() {
 							height="45"
 						/>
 						<p className="font-extrabold ps-1 ms-1 md:ms-3 text-3xl text-[#DAA520]/90">
-							JT Dev Studio
+							Dev Studio
 						</p>
 
 						<div className="animate-flareSpark">


### PR DESCRIPTION
This pull request makes minor updates to the branding and footer text throughout the site to improve clarity and consistency.

Branding updates:

* Changed the main heading in the hero section from "Welcome to JT Dev Studio" to "Welcome to my Dev Studio" in `src/app/page.tsx`.
* Updated the navigation label from "JT Dev Studio" to "Dev Studio" in `src/components/layout/Navigation.tsx`.

Footer update:

* Simplified the footer text by removing the "Complete - Full Stack Software Developer: Walkthrough Guide" phrase, leaving only the copyright notice in `src/components/layout/Footer.tsx`.