### PR TITLE
⚡ Bolt: Remove unnecessary 'use client' from landing page

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-23 - Remove unnecessary "use client" from landing page
+**Learning:** Static landing pages are often marked as "use client" unnecessarily, forcing them to be included in the client-side JavaScript bundle. This increases TTI and FCP without benefit if the page is purely static or uses only Links/Images.
+**Action:** Always verify if "use client" is actually needed for top-level pages. If a page only contains layout, text, images, and links, it should be a Server Component.

--- a/src/__tests__/app/page.test.tsx
+++ b/src/__tests__/app/page.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import LandingPage from '@/app/page'
+
+// Mock next/image
+vi.mock('next/image', () => ({
+  default: ({ src, alt, unoptimized, ...props }: any) => {
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img src={src} alt={alt} {...props} />
+  },
+}))
+
+// Mock next/link
+vi.mock('next/link', () => ({
+  default: ({ children, href }: any) => {
+    return <a href={href}>{children}</a>
+  },
+}))
+
+describe('LandingPage', () => {
+  it('renders the welcome message', () => {
+    render(<LandingPage />)
+    const heading = screen.getByRole('heading', { level: 1 })
+    expect(heading).toHaveTextContent(/Welcome to my Dev Studio/i)
+  })
+
+  it('renders landing cards', () => {
+    render(<LandingPage />)
+    // "About Me" is in the hero and in the cards
+    const aboutLinks = screen.getAllByText('About Me')
+    expect(aboutLinks.length).toBeGreaterThan(0)
+
+    expect(screen.getByText('Live Post Feed')).toBeInTheDocument()
+  })
+})

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,4 @@
 // src/app/page.tsx
-"use client";
 import Link from "next/link";
 import Image from "next/image";
 import { landingCards } from "../lib/landing-cards";


### PR DESCRIPTION
💡 What: Removed the "use client" directive from src/app/page.tsx.
🎯 Why: The landing page is static and does not use any client-side hooks or event listeners. Converting it to a Server Component reduces the initial JavaScript bundle size, improving TTI and FCP.
📊 Impact: Reduced client-side bundle size.
🔬 Measurement: Verified that the page still renders correctly via unit tests and visual inspection.

---
*PR created automatically by Jules for task [4667925367392107730](https://jules.google.com/task/4667925367392107730) started by @TorresjDev*