### PR TITLE
⚡ Bolt: Memoize CommentThread component

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-21 - Recursive Component Memoization
+**Learning:** Recursive components (like `CommentThread`) need a specific pattern for `React.memo` to work effectively. The recursive call must use the memoized export, not the internal function definition.
+**Action:** Use `function BaseComp() { ... <MemoizedComp /> }` and `export const MemoizedComp = memo(BaseComp)`.

--- a/src/__tests__/components/CommentThread.test.tsx
+++ b/src/__tests__/components/CommentThread.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react'
+import { CommentThread } from '@/components/ugc/CommentThread'
+import { vi, describe, it, expect } from 'vitest'
+
+// Mock dependencies
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'test-user' } }),
+}))
+
+vi.mock('@/lib/ugc', () => ({
+  deleteComment: vi.fn(),
+}))
+
+vi.mock('next/image', () => ({
+  default: ({ src, alt, fill, ...props }: any) => {
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img src={src} alt={alt} {...props} />
+  },
+}))
+
+vi.mock('@/components/ugc/utils', () => ({
+  formatDistanceToNow: () => '2 hours ago',
+}))
+
+// Mock CommentForm to avoid complex dependencies
+vi.mock('@/components/ugc/CommentForm', () => ({
+  CommentForm: () => <div data-testid="comment-form">Comment Form</div>,
+}))
+
+describe('CommentThread', () => {
+  const mockComment = {
+    id: '1',
+    content: 'Test comment',
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    author_id: 'test-user',
+    author: {
+      username: 'testuser',
+      avatar_url: '/avatar.png',
+    },
+    replies: [],
+  }
+
+  it('renders comment content', () => {
+    render(
+      <CommentThread
+        comment={mockComment as any}
+        postId="post-1"
+      />
+    )
+    expect(screen.getByText('Test comment')).toBeDefined()
+    expect(screen.getByText('testuser')).toBeDefined()
+  })
+
+  it('renders nested replies', () => {
+    const commentWithReplies = {
+      ...mockComment,
+      replies: [
+        {
+          ...mockComment,
+          id: '2',
+          content: 'Reply comment',
+        }
+      ]
+    }
+
+    render(
+      <CommentThread
+        comment={commentWithReplies as any}
+        postId="post-1"
+      />
+    )
+
+    expect(screen.getByText('Test comment')).toBeDefined()
+    expect(screen.getByText('Reply comment')).toBeDefined()
+  })
+})

--- a/src/components/ugc/CommentThread.tsx
+++ b/src/components/ugc/CommentThread.tsx
@@ -7,7 +7,7 @@
  * Supports editing, deleting, and replying to comments.
  */
 
-import { useState } from 'react'
+import { useState, memo } from 'react'
 import Image from 'next/image'
 import { formatDistanceToNow } from './utils'
 import { useAuth } from '@/context/AuthContext'
@@ -28,7 +28,7 @@ interface CommentThreadProps {
  * Depth = How many levels deep in the reply chain
  * MaxDepth = Limit nesting to prevent infinite indentation
  */
-export function CommentThread({ 
+function CommentThreadBase({
   comment, 
   postId,
   depth = 0, 
@@ -190,6 +190,10 @@ export function CommentThread({
     </div>
   )
 }
+
+// Memoized to prevent unnecessary re-renders of the entire comment tree
+// when parent state changes or when other comments update.
+export const CommentThread = memo(CommentThreadBase)
 
 /**
  * Comments Section


### PR DESCRIPTION
💡 What: Wrapped `CommentThread` in `React.memo` and updated recursive calls to use the memoized version.
🎯 Why: To prevent unnecessary re-renders of the entire comment tree when parent state changes or when sibling comments update. This is critical for deep nested lists.
📊 Impact: Reduces re-renders of unchanged comments.
🔬 Measurement: Verified with unit tests ensuring component renders correctly with new structure.

---
*PR created automatically by Jules for task [7939014024842065701](https://jules.google.com/task/7939014024842065701) started by @TorresjDev*