### PR TITLE
⚡ Bolt: Memoize CommentThread component

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-20 - Recursive Component Memoization
+**Learning:** When memoizing recursive components (like `CommentThread`), you must ensure the recursive call inside the component uses the memoized version of itself, not the base component. This requires separating the base logic and the exported memoized component.
+**Action:** Use `const ComponentBase = ...` then `export const Component = memo(ComponentBase)` and ensure `ComponentBase` renders `Component` recursively.

--- a/src/__tests__/components/CommentThread.perf.test.tsx
+++ b/src/__tests__/components/CommentThread.perf.test.tsx
@@ -1,0 +1,78 @@
+import { render } from '@testing-library/react'
+import { CommentThread } from '@/components/ugc/CommentThread'
+import { useAuth } from '@/context/AuthContext'
+import { vi, describe, it, expect } from 'vitest'
+import type { CommentThread as CommentThreadType } from '@/lib/ugc'
+
+// Mock dependencies
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: vi.fn(),
+}))
+
+vi.mock('next/image', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars, @next/next/no-img-element
+  default: ({ fill, ...props }: any) => <img {...props} alt={props.alt} />
+}))
+
+vi.mock('next/link', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  default: ({ children }: any) => children
+}))
+
+// Mock imports used in CommentThread
+vi.mock('@/lib/ugc', () => ({
+  deleteComment: vi.fn(),
+}))
+
+vi.mock('@/components/ugc/utils', () => ({
+  formatDistanceToNow: () => '1 min ago'
+}))
+
+vi.mock('@/components/ugc/CommentForm', () => ({
+  CommentForm: () => <div data-testid="comment-form" />
+}))
+
+describe('CommentThread Performance', () => {
+  it('prevents re-render when props are stable (memoization)', () => {
+    const mockUseAuth = vi.mocked(useAuth)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockUseAuth.mockReturnValue({ user: { id: 'user1' } } as any)
+    mockUseAuth.mockClear()
+
+    const comment: CommentThreadType = {
+      id: 'c1',
+      content: 'Hello',
+      author_id: 'user1',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      replies: [],
+      author: {
+        id: 'user1', // Added id to match typical profile type
+        username: 'user1',
+        display_name: 'User 1',
+        avatar_url: 'http://example.com/avatar.jpg',
+        website: null,
+        bio: null,
+        created_at: '',
+        updated_at: ''
+      },
+      post_id: 'p1',
+      parent_comment_id: null
+    }
+
+    const { rerender } = render(
+      <CommentThread comment={comment} postId="p1" />
+    )
+
+    // Initial render
+    expect(mockUseAuth).toHaveBeenCalledTimes(1)
+
+    // Rerender with SAME props object (reference equality)
+    rerender(
+      <CommentThread comment={comment} postId="p1" />
+    )
+
+    // With memoization, it should NOT re-render
+    expect(mockUseAuth).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/ugc/CommentThread.tsx
+++ b/src/components/ugc/CommentThread.tsx
@@ -7,7 +7,7 @@
  * Supports editing, deleting, and replying to comments.
  */
 
-import { useState } from 'react'
+import { useState, memo } from 'react'
 import Image from 'next/image'
 import { formatDistanceToNow } from './utils'
 import { useAuth } from '@/context/AuthContext'
@@ -28,12 +28,12 @@ interface CommentThreadProps {
  * Depth = How many levels deep in the reply chain
  * MaxDepth = Limit nesting to prevent infinite indentation
  */
-export function CommentThread({ 
+const CommentThreadBase = ({
   comment, 
   postId,
   depth = 0, 
   maxDepth = 3 
-}: CommentThreadProps) {
+}: CommentThreadProps) => {
   const { user } = useAuth()
   const [isReplying, setIsReplying] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
@@ -190,6 +190,9 @@ export function CommentThread({
     </div>
   )
 }
+
+export const CommentThread = memo(CommentThreadBase)
+CommentThread.displayName = 'CommentThread'
 
 /**
  * Comments Section


### PR DESCRIPTION
💡 What:
Applied `React.memo` to the `CommentThread` component and restructured it to support recursive memoization.

🎯 Why:
The `CommentThread` component is recursive. Without memoization, any update to the parent (like `CommentsSection`) or a parent comment causes the entire subtree of replies to re-render. This leads to performance degradation in deep threads.

📊 Impact:
Reduces re-renders of nested comments to 0 when props (comment data) are stable.
Verified with a performance test that confirms re-renders dropped from 2 to 1 (initial render only) during a parent re-render.

🔬 Measurement:
Run `npm test src/__tests__/components/CommentThread.perf.test.tsx` to verify that `useAuth` is called only once per component instance when props are stable.

---
*PR created automatically by Jules for task [9567716643439777524](https://jules.google.com/task/9567716643439777524) started by @TorresjDev*