### PR TITLE
⚡ Bolt: Memoize CommentThread to prevent recursive re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-25 - Recursive Component Performance
+**Learning:** Recursive components (like `CommentThread`) without memoization trigger re-renders for the entire subtree when the parent updates, even if props are unchanged. This is a common bottleneck in threaded UI.
+**Action:** Always wrap recursive UI components in `React.memo` and ensure the internal recursive call uses the memoized component reference.

--- a/src/__tests__/components/CommentThread.perf.test.tsx
+++ b/src/__tests__/components/CommentThread.perf.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react'
+import { CommentThread } from '@/components/ugc/CommentThread'
+import { vi, describe, it, expect } from 'vitest'
+import type { CommentThread as CommentThreadType } from '@/lib/ugc'
+
+// Mocks
+vi.mock('next/image', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
+  default: ({ fill, ...props }: any) => {
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    return <img {...props} />
+  }
+}))
+
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: 'user-1', email: 'test@example.com' }
+  })
+}))
+
+vi.mock('@/lib/ugc', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/ugc')>()
+  return {
+    ...actual,
+    deleteComment: vi.fn().mockResolvedValue({ success: true }),
+  }
+})
+
+vi.mock('@/components/ugc/CommentForm', () => ({
+  CommentForm: () => <div data-testid="comment-form">CommentForm</div>
+}))
+
+// Utils mock
+vi.mock('@/components/ugc/utils', () => ({
+  formatDistanceToNow: () => '2 hours ago'
+}))
+
+describe('CommentThread', () => {
+  const mockAuthor = {
+    id: 'user-1',
+    username: 'tester',
+    display_name: 'Tester',
+    avatar_url: 'http://example.com/avatar.jpg'
+  }
+
+  const mockComment: CommentThreadType = {
+    id: 'c1',
+    post_id: 'p1',
+    author_id: 'user-1',
+    parent_comment_id: null,
+    content: 'This is a test comment',
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    author: mockAuthor,
+    replies: []
+  }
+
+  it('renders comment content correctly', () => {
+    render(
+      <CommentThread
+        comment={mockComment}
+        postId="p1"
+      />
+    )
+
+    expect(screen.getByText('This is a test comment')).toBeInTheDocument()
+    expect(screen.getByText('Tester')).toBeInTheDocument()
+    expect(screen.getByText('2 hours ago')).toBeInTheDocument()
+  })
+
+  it('renders nested replies', () => {
+    const commentWithReply: CommentThreadType = {
+      ...mockComment,
+      replies: [
+        {
+          ...mockComment,
+          id: 'c2',
+          content: 'This is a reply',
+          replies: []
+        }
+      ]
+    }
+
+    render(
+      <CommentThread
+        comment={commentWithReply}
+        postId="p1"
+      />
+    )
+
+    expect(screen.getByText('This is a test comment')).toBeInTheDocument()
+    expect(screen.getByText('This is a reply')).toBeInTheDocument()
+  })
+})

--- a/src/components/ugc/CommentThread.tsx
+++ b/src/components/ugc/CommentThread.tsx
@@ -7,7 +7,7 @@
  * Supports editing, deleting, and replying to comments.
  */
 
-import { useState } from 'react'
+import { useState, memo } from 'react'
 import Image from 'next/image'
 import { formatDistanceToNow } from './utils'
 import { useAuth } from '@/context/AuthContext'
@@ -28,7 +28,7 @@ interface CommentThreadProps {
  * Depth = How many levels deep in the reply chain
  * MaxDepth = Limit nesting to prevent infinite indentation
  */
-export function CommentThread({ 
+function CommentThreadBase({
   comment, 
   postId,
   depth = 0, 
@@ -190,6 +190,8 @@ export function CommentThread({
     </div>
   )
 }
+
+export const CommentThread = memo(CommentThreadBase)
 
 /**
  * Comments Section


### PR DESCRIPTION
💡 What: Wrapped `CommentThread` in `React.memo` and ensured the recursive calls use the memoized component.

🎯 Why: Recursive components like `CommentThread` cause the entire subtree to re-render when the parent updates (e.g. `CommentsSection` update or parent comment interaction), even if the children props haven't changed. This is an O(N) operation where N is the number of comments in the thread.

📊 Impact: Reduces re-renders from O(N) to O(1) (for the updated node) or O(depth) (for the path to the updated node) when a comment is updated or when the parent re-renders without data changes.

🔬 Measurement: Added `src/__tests__/components/CommentThread.perf.test.tsx` to verify the component still renders correctly. The performance benefit is inherent to `React.memo` preventing re-execution of the component function when props are shallowly equal.

---
*PR created automatically by Jules for task [2583962520809705478](https://jules.google.com/task/2583962520809705478) started by @TorresjDev*