### PR TITLE
⚡ Bolt: Memoize CommentThread to prevent recursive re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,7 @@
+## 2026-02-05 - Recursive Component Memoization
+**Learning:** Recursive components (e.g., `CommentThread`) must be split into a content function and an exported `React.memo` wrapper. The content function must render the *exported wrapper* recursively to ensure nested children benefit from memoization.
+**Action:** When optimizing recursive components, refactor to `function Content() { ... return <ExportedMemoized ... /> }`.
+
+## 2026-02-05 - Vitest Mock Paths
+**Learning:** `vi.mock` paths are resolved relative to the test file unless an alias is used. If the SUT imports using relative paths or aliases, the mock must match how the module system resolves it. Safest bet is to mock the alias (e.g., `@/components/...`).
+**Action:** Use aliases in `vi.mock` to ensure consistent mocking regardless of test file location.

--- a/src/__tests__/components/CommentThread.perf.test.tsx
+++ b/src/__tests__/components/CommentThread.perf.test.tsx
@@ -1,0 +1,93 @@
+import { render, fireEvent, screen } from '@testing-library/react'
+import { vi, describe, it, expect, afterEach } from 'vitest'
+import { CommentThread } from '@/components/ugc/CommentThread'
+
+// Mock dependencies
+const mockUseAuth = vi.fn(() => ({
+  user: { id: 'user-1', username: 'tester' },
+  loading: false
+}))
+
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: () => mockUseAuth()
+}))
+
+vi.mock('@/lib/ugc', () => ({
+  deleteComment: vi.fn(),
+}))
+
+// Mock CommentForm component to avoid its internal logic/renders interfering
+vi.mock('@/components/ugc/CommentForm', () => ({
+  CommentForm: () => <div data-testid="comment-form">Comment Form</div>
+}))
+
+// We use formatDistanceToNow as a proxy to count renders of the CommentThread component
+// since it is called directly in the render body.
+const mockFormatDistanceToNow = vi.fn(() => '2 hours ago')
+
+vi.mock('@/components/ugc/utils', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  formatDistanceToNow: (...args: any[]) => mockFormatDistanceToNow(...args),
+  formatDate: vi.fn(),
+  formatDateTime: vi.fn(),
+}))
+
+vi.mock('next/image', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+  default: ({ fill: _fill, ...props }: any) => {
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img {...props} alt={props.alt || ''} />
+  }
+}))
+
+describe('CommentThread Performance', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should not re-render child comments when parent state updates', () => {
+    const childComment = {
+      id: 'child-1',
+      content: 'Child comment',
+      author_id: 'user-2',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      author: { username: 'other', avatar_url: null },
+      replies: []
+    }
+
+    const parentComment = {
+      id: 'parent-1',
+      content: 'Parent comment',
+      author_id: 'user-3',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      author: { username: 'parent-author', avatar_url: null },
+      replies: [childComment]
+    }
+
+    render(
+      <CommentThread
+        comment={parentComment}
+        postId="post-1"
+      />
+    )
+
+    // Initial render: Parent + Child = 2 calls
+    expect(mockFormatDistanceToNow).toHaveBeenCalledTimes(2)
+
+    // Clear mocks to measure update renders only
+    mockFormatDistanceToNow.mockClear()
+
+    // Trigger state update on Parent by clicking "Reply"
+    const replyButtons = screen.getAllByText('Reply')
+    fireEvent.click(replyButtons[0]) // Click parent's reply button
+
+    // Assert expectation:
+    // Without memoization: Parent updates (1) + Child updates (1) = 2 calls
+    // With memoization: Parent updates (1) + Child skips update (0) = 1 call
+
+    // We assert 1 call to enforce the optimization
+    expect(mockFormatDistanceToNow).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/ugc/CommentThread.tsx
+++ b/src/components/ugc/CommentThread.tsx
@@ -7,7 +7,7 @@
  * Supports editing, deleting, and replying to comments.
  */
 
-import { useState } from 'react'
+import { useState, memo } from 'react'
 import Image from 'next/image'
 import { formatDistanceToNow } from './utils'
 import { useAuth } from '@/context/AuthContext'
@@ -28,7 +28,7 @@ interface CommentThreadProps {
  * Depth = How many levels deep in the reply chain
  * MaxDepth = Limit nesting to prevent infinite indentation
  */
-export function CommentThread({ 
+function CommentThreadContent({
   comment, 
   postId,
   depth = 0, 
@@ -190,6 +190,8 @@ export function CommentThread({
     </div>
   )
 }
+
+export const CommentThread = memo(CommentThreadContent)
 
 /**
  * Comments Section


### PR DESCRIPTION
💡 What:
Wrapped `CommentThread` component in `React.memo` and refactored it to ensure recursive calls use the memoized version.

🎯 Why:
The `CommentThread` component renders recursively for nested replies. When a parent comment updates (e.g., toggling the reply form), it triggers a re-render of its entire subtree. Without memoization, all child comments re-render unnecessarily, which is expensive for deep threads.

📊 Impact:
Reduces re-renders of nested comments to 0 when parent state changes (unless props change).
In a thread with N replies, an update to the root comment previously caused N re-renders; now it causes 0 child re-renders.

🔬 Measurement:
Added a performance test `src/__tests__/components/CommentThread.perf.test.tsx` that counts renders by spying on `formatDistanceToNow`.
- Baseline: 2 renders (Parent + Child) on update.
- Optimized: 1 render (Parent only) on update.

---
*PR created automatically by Jules for task [11368612730327969022](https://jules.google.com/task/11368612730327969022) started by @TorresjDev*