### PR TITLE
feat: Add About page with dynamic GitHub profile display, dedicated sidebar navigation, and integrate layout components.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"scripts": {
 		"dev": "next dev",
 		"build": "next build",
+		"build:webpack": "next build --webpack",
 		"start": "next start",
 		"lint": "next lint",
 		"test": "vitest",

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -86,12 +86,12 @@ export default async function AboutPage({
 					</div>
 				</div>
 			) : (
-				<div className="flex flex-col items-center justify-center p-12 rounded-3xl bg-white/2 border border-white/5 backdrop-blur-xl animate-in fade-in duration-700">
-					<div className="w-20 h-20 rounded-full bg-white/5 flex items-center justify-center mb-6">
+				<div className="flex flex-col items-center justify-center p-12 rounded-3xl bg-accent/10 border border-border backdrop-blur-xl animate-in fade-in duration-700">
+					<div className="w-20 h-20 rounded-full bg-accent/20 flex items-center justify-center mb-6">
 						<AlertCircle className="w-10 h-10 text-[#DAA520]/40" />
 					</div>
-					<h2 className="text-2xl font-bold text-white mb-2">Profile Not Linked</h2>
-					<p className="text-white/40 text-center max-w-md mb-8">
+					<h2 className="text-2xl font-bold text-foreground mb-2">Profile Not Linked</h2>
+					<p className="text-muted-foreground text-center max-w-md mb-8">
 						Link your GitHub account during login to see your real-time statistics and contributions here.
 					</p>
 					<Button asChild className="bg-[#DAA520] hover:bg-[#DAA520]/80 text-black font-bold px-8">
@@ -101,8 +101,8 @@ export default async function AboutPage({
 			)}
 
 			{/* Bio Section/Placeholder */}
-			<div className="relative p-6 md:p-8 rounded-2xl bg-white/5 border border-white/10 backdrop-blur-sm shadow-xl">
-				<p className="text-lg md:text-xl leading-relaxed text-gray-200/90 font-light text-center md:text-left">
+			<div className="relative p-6 md:p-8 rounded-2xl bg-accent/20 border border-border backdrop-blur-sm shadow-xl">
+				<p className="text-lg md:text-xl leading-relaxed text-foreground/90 font-light text-center md:text-left">
 					<span className="mr-2 text-2xl">💻</span>
 					{isSelf ? (
 						`Welcome ${profile?.name || githubUsername}! Here is a quick look at your development activity and profile stats directly from GitHub.`
@@ -118,7 +118,7 @@ export default async function AboutPage({
 			{profile ? (
 				<section className="space-y-8 animate-in slide-in-from-bottom-5 duration-700 delay-200">
 					<div className="flex justify-center">
-						<div className="relative group overflow-hidden rounded-xl border border-white/10 shadow-2xl hover:shadow-[#DAA520]/10 hover:border-[#DAA520]/30 transition-all duration-500 bg-black/40">
+						<div className="relative group overflow-hidden rounded-xl border border-border shadow-2xl hover:shadow-[#DAA520]/10 hover:border-[#DAA520]/30 transition-all duration-500 bg-card/40">
 							<img 
 								src={`https://githubcard.com/${profile.login}.svg?d=ej5sfIat`} 
 								alt="GitHub Card" 
@@ -131,21 +131,21 @@ export default async function AboutPage({
 						<h2 className="text-xl md:text-2xl font-bold text-[#DAA520]/90 tracking-wide uppercase">
 							Contribution Activity
 						</h2>
-						<div className="w-full overflow-hidden rounded-xl border border-white/10 bg-white/5 p-4 md:p-6 shadow-inner hover:bg-white/[0.07] transition-colors">
+						<div className="w-full overflow-hidden rounded-xl border border-border bg-card p-4 md:p-6 shadow-inner hover:bg-accent/10 transition-colors">
 							<img
 								src={`https://ghchart.rshah.org/DAA520/${profile.login}`}
 								alt="GitHub Contributions"
-								className="w-full h-auto min-w-[600px] mx-auto opacity-90 hover:opacity-100 transition-opacity"
+								className="w-full h-auto min-w-[600px] mx-auto opacity-90 dark:invert-0 hover:opacity-100 transition-opacity"
 							/>
 						</div>
 					</div>
 				</section>
 			) : (
 				<div className="grid grid-cols-1 md:grid-cols-2 gap-8 opacity-40 grayscale pointer-events-none">
-					<div className="h-48 bg-white/5 rounded-2xl border border-white/10 flex items-center justify-center">
+					<div className="h-48 bg-accent/5 rounded-2xl border border-border flex items-center justify-center">
 						<span className="text-sm font-medium">Stats Card Placeholder</span>
 					</div>
-					<div className="h-48 bg-white/5 rounded-2xl border border-white/10 flex items-center justify-center">
+					<div className="h-48 bg-accent/5 rounded-2xl border border-border flex items-center justify-center">
 						<span className="text-sm font-medium">Contribution Chart Placeholder</span>
 					</div>
 				</div>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -8,23 +8,27 @@ import { createClient } from "@/utils/supabase/server";
 import { Github, Globe, AlertCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
-export default async function AboutPage() {
+export default async function AboutPage({
+	searchParams,
+}: {
+	searchParams: Promise<{ username?: string }>;
+}) {
+	const { username: queryUsername } = await searchParams;
 	const supabase = await createClient();
 	const { data: { user } } = await supabase.auth.getUser();
 
-	// Extract GitHub username if available
-	const githubUsername = user?.user_metadata?.user_name || user?.user_metadata?.preferred_username;
-	const isGithubUser = !!githubUsername;
+	// Extract GitHub username if available from session
+	const sessionUsername = user?.user_metadata?.user_name || user?.user_metadata?.preferred_username;
+	
+	// Priority: 1. query param, 2. logged in user, 3. creator default
+	const githubUsername = queryUsername || sessionUsername || "torresjdev";
+	const isCreator = githubUsername === "torresjdev";
+	const isSelf = !!sessionUsername && githubUsername === sessionUsername;
 	
 	let profile = null;
 
 	try {
-		if (isGithubUser) {
-			profile = await getGitHubProfile(githubUsername);
-		} else if (!user) {
-			// If not logged in, show the site owner's profile (original behavior)
-			profile = await getGitHubProfile();
-		}
+		profile = await getGitHubProfile(githubUsername);
 	} catch (e) {
 		console.error("Error fetching github profile:", e);
 	}
@@ -100,16 +104,18 @@ export default async function AboutPage() {
 			<div className="relative p-6 md:p-8 rounded-2xl bg-white/5 border border-white/10 backdrop-blur-sm shadow-xl">
 				<p className="text-lg md:text-xl leading-relaxed text-gray-200/90 font-light text-center md:text-left">
 					<span className="mr-2 text-2xl">💻</span>
-					{isGithubUser ? (
+					{isSelf ? (
 						`Welcome ${profile?.name || githubUsername}! Here is a quick look at your development activity and profile stats directly from GitHub.`
+					) : isCreator ? (
+						`Welcome to my portfolio! I'm ${profile?.name || "the creator"}. Here's a look at my development activity and projects.`
 					) : (
-						"I'm a software engineer with hands-on experience in full-stack development. Link your GitHub to showcase your technical footprint here."
+						`Viewing profile for ${profile?.name || githubUsername}. Showcase your own technical footprint by linking your GitHub.`
 					)}
 				</p>
 			</div>
 
 			{/* GitHub Stats Grid */}
-			{(isGithubUser || (!user && profile)) && profile ? (
+			{profile ? (
 				<section className="space-y-8 animate-in slide-in-from-bottom-5 duration-700 delay-200">
 					<div className="flex justify-center">
 						<div className="relative group overflow-hidden rounded-xl border border-white/10 shadow-2xl hover:shadow-[#DAA520]/10 hover:border-[#DAA520]/30 transition-all duration-500 bg-black/40">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,16 +21,16 @@ export default function RootLayout({
 		<html lang="en" suppressHydrationWarning>
 			<body className={inter.className}>
 				<AuthProvider>
-					<Navigation />
 					<ThemeProvider
-						enableSystem={false}
+						enableSystem
 						disableTransitionOnChange
 						attribute="class"
 						defaultTheme="dark"
 					>
+						<Navigation />
 						<LayoutContent>{children}</LayoutContent>
+						<Footer />
 					</ThemeProvider>
-					<Footer />
 				</AuthProvider>
 			</body>
 		</html>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,24 +1,23 @@
-// pages/404.js
 import Link from "next/link";
-import Image from "next/image";
 
-export default function Custom404() {
+export default function NotFound() {
 	return (
 		<div className="flex flex-col items-center justify-center min-h-screen p-4 text-center w-[90vw] lg:w-[69vw] max-w-[95vw] mx-auto">
 			<h1 className="text-4xl font-bold text-abn/90">Page Not Found</h1>
-			<Image
+			<img
 				src="https://torresjdev.github.io/Nextjs-Asset-Host/assets/backgrounds/ui/404-not-found-transparent.png"
 				alt="Not Found"
 				className="mt-8 w-1/2"
 				width={500}
 				height={500}
-			></Image>
+				loading="lazy"
+			/>
 
 			<p className="mt-4 text-lg text-silver/60">
 				We can&apos;t seem to find the page you&apos;re looking for.
 			</p>
-			<Link href="/" className="my-3 ">
-				<p className=" hover:!text-[#DAA520]">Go back home</p>
+			<Link href="/" className="my-3 hover:!text-[#DAA520]">
+				Go back home
 			</Link>
 		</div>
 	);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ import { landingCards } from "../lib/landing-cards";
 
 export default function LandingPage() {
 	return (
-		<main className="space-y-24 px-4 md:px-10 py-16 text-foreground max-w-7xl mx-auto overflow-y-scroll scroll-m-0">
+		<main className="space-y-24 px-4 md:px-10 py-16 text-foreground max-w-7xl mx-auto">
 			{/* Hero Section */}
 			<section className="text-center">
 				<h1 className="text-5xl font-extrabold text-foreground tracking-tight">

--- a/src/components/layout/LayoutContent.tsx
+++ b/src/components/layout/LayoutContent.tsx
@@ -21,19 +21,22 @@ export function LayoutContent({ children }: { children: React.ReactNode }) {
 
   return (
     <SidebarProvider>
-      <div className="flex max-h-full max-w-full w-full">
-        <aside>
-          <SidebarNav />
-        </aside>
-        <main className="w-full flex flex-1 mx-2 mt-24 sm:mt-20 md:mt-16 p-3 md:p-1 transition-all duration-300 ease-in-out md:ml-60 group-data-[state=collapsed]/sidebar-wrapper:md:ml-12"> 
-        {/* md:ml-[15rem] group-data-[state=collapsed]/sidebar-wrapper:md:ml-[3rem] */}
-          <SidebarTrigger />
-          <section className="w-full flex flex-col mx-auto min-h-[95vh] overflow-y-auto px-2">
-            <Suspense fallback={<div className="animate-spin text-white">Loading...</div>}>
+      <div className="flex min-h-screen w-full">
+        <SidebarNav />
+        <div className="flex-1 flex flex-col min-w-0">
+          <header className="flex h-14 shrink-0 items-center justify-between gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12 border-b px-4">
+            <SidebarTrigger className="-ml-1" />
+          </header>
+          <main className="flex-1 overflow-auto p-4 md:p-6 lg:p-8">
+            <Suspense fallback={
+              <div className="flex items-center justify-center min-h-[50vh]">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#DAA520]"></div>
+              </div>
+            }>
               {children}
             </Suspense>
-          </section>
-        </main>
+          </main>
+        </div>
       </div>
     </SidebarProvider>
   )

--- a/src/components/layout/sidebar/AboutSidebarGroup.tsx
+++ b/src/components/layout/sidebar/AboutSidebarGroup.tsx
@@ -1,6 +1,6 @@
 "use client";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import {
 	SidebarGroup,
 	SidebarGroupContent,
@@ -14,7 +14,12 @@ import Icon from "../../ui/icon";
 
 export default function AboutSidebarGroup() {
 	const pathname = usePathname();
+	const searchParams = useSearchParams();
 	const { isMobile, setOpenMobile } = useSidebar();
+
+	const username = searchParams.get("username");
+	const isCreatorActive = pathname === "/about" && username === "torresjdev";
+	const isProfileActive = pathname === "/about" && !username;
 
 	return (
 		<SidebarGroup>
@@ -22,20 +27,32 @@ export default function AboutSidebarGroup() {
 			<SidebarGroupContent>
 				<SidebarMenu>
 					<SidebarMenuItem>
-						<div className="flex items-center gap-2 cursor-pointer">
-							<SidebarMenuButton asChild isActive={pathname === "/about"}>
-								<Link
-									href="/about"
-									onClick={() => isMobile && setOpenMobile(false)}
-								>
-									<Icon
-										name="person"
-										className="rounded-full p-0.5 bg-white font-medium"
-									/>
-									<span className="">Profile</span>
-								</Link>
-							</SidebarMenuButton>
-						</div>
+						<SidebarMenuButton asChild isActive={isCreatorActive}>
+							<Link
+								href="/about?username=torresjdev"
+								onClick={() => isMobile && setOpenMobile(false)}
+							>
+								<Icon
+									name="code"
+									className="rounded-full p-0.5 bg-[#DAA520] font-medium text-black"
+								/>
+								<span className="">Creator</span>
+							</Link>
+						</SidebarMenuButton>
+					</SidebarMenuItem>
+					<SidebarMenuItem>
+						<SidebarMenuButton asChild isActive={isProfileActive}>
+							<Link
+								href="/about"
+								onClick={() => isMobile && setOpenMobile(false)}
+							>
+								<Icon
+									name="person"
+									className="rounded-full p-0.5 bg-white font-medium text-black"
+								/>
+								<span className="">Profile</span>
+							</Link>
+						</SidebarMenuButton>
 					</SidebarMenuItem>
 				</SidebarMenu>
 			</SidebarGroupContent>

--- a/src/components/layout/sidebar/AboutSidebarGroup.tsx
+++ b/src/components/layout/sidebar/AboutSidebarGroup.tsx
@@ -48,7 +48,7 @@ export default function AboutSidebarGroup() {
 							>
 								<Icon
 									name="person"
-									className="rounded-full p-0.5 bg-white font-medium text-black"
+									className="rounded-full p-0.5 bg-foreground/10 font-medium text-foreground"
 								/>
 								<span className="">Profile</span>
 							</Link>

--- a/src/components/layout/sidebar/SidebarNav.tsx
+++ b/src/components/layout/sidebar/SidebarNav.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { Suspense } from "react";
 import { Sidebar, SidebarContent, SidebarFooter } from "../../ui/sidebar";
 import AboutSidebarGroup from "./AboutSidebarGroup";
 import PostSidebarGroup from "./PostSidebarGroup";
@@ -9,7 +10,9 @@ export function SidebarNav() {
 	return (
 		<Sidebar className="top-[60px]">
 			<SidebarContent>
-				<AboutSidebarGroup />
+				<Suspense fallback={null}>
+					<AboutSidebarGroup />
+				</Suspense>
 				<PostSidebarGroup />
 				<SupportSidebarGroup />
 				{/* need group for ai resume builder*/}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -140,7 +140,7 @@ const SidebarProvider = React.forwardRef<
 						}
 						data-state={state}
 						className={cn(
-							"group/sidebar-wrapper flex min-h-svh w-full has-[[data-variant=inset]]:bg-transparent",
+							"group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-transparent",
 							className
 						)}
 						ref={ref}
@@ -197,7 +197,7 @@ const Sidebar = React.forwardRef<
 					<SheetContent
 						data-sidebar="sidebar"
 						data-mobile="true"
-						className="!w-full !max-w-full !inset-x-0 !top-14 !h-auto !max-h-[70vh] bg-zinc-900/98 backdrop-blur-xl border-b border-[#DAA520]/30 p-0 text-sidebar-foreground [&>button]:hidden shadow-2xl rounded-b-2xl overflow-y-auto"
+						className="w-full! max-w-full! inset-x-0! top-14! h-auto! max-h-[70vh]! bg-sidebar/98 backdrop-blur-xl border-b border-sidebar-border p-0 text-sidebar-foreground [&>button]:hidden shadow-2xl rounded-b-2xl overflow-y-auto"
 						side="top"
 					>
 						{/* Mobile Menu Content */}
@@ -223,7 +223,7 @@ const Sidebar = React.forwardRef<
 						"group-data-[collapsible=offcanvas]:w-0",
 						"group-data-[side=right]:rotate-180",
 						variant === "floating" || variant === "inset"
-							? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4))]"
+							? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]"
 							: "group-data-[collapsible=icon]:w-[--sidebar-width-icon]"
 					)}
 				/>
@@ -235,7 +235,7 @@ const Sidebar = React.forwardRef<
 							: "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
 						// Adjust the padding for floating and inset variants.
 						variant === "floating" || variant === "inset"
-							? "px-2 py-1 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4)_+2px)]"
+							? "px-2 py-1 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
 							: "group-data-[collapsible=icon]:w-[--sidebar-width-icon] group-data-[side=left]:border-r group-data-[side=right]:border-l",
 						className
 					)}
@@ -243,7 +243,7 @@ const Sidebar = React.forwardRef<
 				>
 					<div
 						data-sidebar="sidebar"
-						className="flex h-full w-[--sidebar-width*3] flex-col bg-zinc-900/95 backdrop-blur-xl group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
+						className="flex h-full w-[--sidebar-width*3] flex-col bg-sidebar/95 backdrop-blur-xl group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
 					>
 						{children}
 					</div>
@@ -268,15 +268,15 @@ const SidebarTrigger = React.forwardRef<
 			size="icon"
 			className={cn(
 				// Mobile: in navbar, far right | Desktop: on sidebar border
-				"h-14 w-14 md:h-10 md:w-10 z-[61] hover:text-[#DAA520]/90 shrink-0",
+				"h-14 w-14 md:h-10 md:w-10 z-61 hover:text-[#DAA520]/90 shrink-0",
 				"absolute transition-all duration-300 ease-in-out",
 				// Mobile: top right of navbar
 				"top-1 right-4",
 				// Desktop: on sidebar border edge
 				"md:top-16 md:right-auto md:-translate-x-1/2",
 				state === "expanded" 
-					? "md:left-[var(--sidebar-width)]" 
-					: "md:left-[var(--sidebar-width-icon)]",
+					? "md:left-(--sidebar-width)" 
+					: "md:left-(--sidebar-width-icon)",
 				className
 			)}
 			onClick={(event) => {
@@ -288,12 +288,12 @@ const SidebarTrigger = React.forwardRef<
 			{state === "expanded" ? (
 				<Icon
 					name="right_panel_open"
-					className="align-bottom !text-white !text-5xl md:!text-4xl"
+					className="align-bottom text-white! text-5xl! md:text-4xl!"
 				/>
 			) : (
 				<Icon
 					name="left_panel_open"
-					className="align-bottom !text-white !text-5xl md:!text-4xl"
+					className="align-bottom text-white! text-5xl! md:text-4xl!"
 				/>
 			)}
 
@@ -319,8 +319,7 @@ const SidebarRail = React.forwardRef<
 			title="Toggle Sidebar"
 			className={cn(
 				"absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
-				"[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",
-				"[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+				"in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
 				"group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar",
 				"[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
 				"[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
@@ -341,7 +340,7 @@ const SidebarInset = React.forwardRef<
 			ref={ref}
 			className={cn(
 				"relative flex min-h-svh flex-1 flex-col bg-background",
-				"peer-data-[variant=inset]:min-h-[calc(100svh-theme(spacing.4))] md:peer-data-[variant=inset]:m-2 md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow",
+				"peer-data-[variant=inset]:min-h-[calc(100svh-(--spacing(4)))] md:peer-data-[variant=inset]:m-2 md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow",
 				className
 			)}
 			{...props}
@@ -534,7 +533,7 @@ const SidebarMenuItem = React.forwardRef<
 SidebarMenuItem.displayName = "SidebarMenuItem";
 
 const sidebarMenuButtonVariants = cva(
-	"peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-white disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:border data-[active=true]:border-white data-[active=true]:font-medium data-[active=true]:text-white data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+	"peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-white disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:border data-[active=true]:border-sidebar-border data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
 	{
 		variants: {
 			variant: {

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -14,11 +14,13 @@ export function ThemeToggle() {
       variant="ghost"
       size="icon"
       onClick={() => setTheme(theme === "light" ? "dark" : "light")}
-      className="h-9 w-9 rounded-full border border-white/10 bg-white/5 hover:bg-white/10 text-foreground"
+      className="h-9 w-9 rounded-full border border-border bg-background/50 backdrop-blur-sm hover:bg-accent hover:text-accent-foreground transition-all duration-300"
       aria-label="Toggle theme"
-    >
-      <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-      <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+    >{theme === "light" ? (
+      <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all text-amber-500" />
+    ) : (
+      <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100 text-slate-400" />
+    )}
     </Button>
   )
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,7 @@
 import { type NextRequest } from 'next/server'
 import { updateSession } from '@/utils/supabase/middleware'
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   return await updateSession(request)
 }
 


### PR DESCRIPTION
This pull request refactors the About page and its sidebar navigation to improve user experience and clarity when viewing profiles. The main changes include prioritizing the display of the creator's profile, updating the sidebar to distinguish between "Creator" and "Profile" views, and enhancing layout and theming for consistency.

**About Page Logic and UI Improvements:**

- The About page now prioritizes the display of a GitHub profile based on the following order: query parameter (`username`), logged-in user, or the creator's default profile. It also customizes welcome messages and profile displays for self, creator, and other users. [[1]](diffhunk://#diff-d38aaae18142756b8b93ec0043df16888550dfded455e182cc0e4a81eb8286e2L11-L27) [[2]](diffhunk://#diff-d38aaae18142756b8b93ec0043df16888550dfded455e182cc0e4a81eb8286e2L103-R118)

**Sidebar Navigation Enhancements:**

- The sidebar now features distinct "Creator" and "Profile" menu items, with active state logic based on the current URL and query parameters. This makes it clearer whether the user is viewing the creator's portfolio or their own profile. [[1]](diffhunk://#diff-8ea346f708a241d212f1e7d711bb658b42b430b02309159c46e462e8c4e79df7L3-R3) [[2]](diffhunk://#diff-8ea346f708a241d212f1e7d711bb658b42b430b02309159c46e462e8c4e79df7R17-L38)

**Layout and Theming Updates:**

- The main layout (`LayoutContent`) was updated for better structure, including a fixed header with a sidebar trigger, improved loading states, and consistent minimum heights.
- The root layout now enables system theme by default for a better user experience and moves the navigation component inside the theme provider for consistent theming.