### PR TITLE
feat: Implement a contact page with a form that saves submissions to Supabase and sends emails through a new API route using Resend.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
 				"next-themes": "^0.4.6",
 				"react": "^19.2.4",
 				"react-dom": "^19.2.4",
+				"resend": "^4.8.0",
 				"server-only": "^0.0.1",
 				"stripe": "^20.4.1",
 				"tailwind-merge": "^3.5.0",
@@ -2605,6 +2606,24 @@
 				"react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
 			}
 		},
+		"node_modules/@react-email/render": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@react-email/render/-/render-1.1.2.tgz",
+			"integrity": "sha512-RnRehYN3v9gVlNMehHPHhyp2RQo7+pSkHDtXPvg3s0GbzM9SQMW4Qrf8GRNvtpLC4gsI+Wt0VatNRUFqjvevbw==",
+			"license": "MIT",
+			"dependencies": {
+				"html-to-text": "^9.0.5",
+				"prettier": "^3.5.3",
+				"react-promise-suspense": "^0.3.4"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"react": "^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
+			}
+		},
 		"node_modules/@react-stately/flags": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.2.tgz",
@@ -2991,6 +3010,19 @@
 			"integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@selderee/plugin-htmlparser2": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+			"integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+			"license": "MIT",
+			"dependencies": {
+				"domhandler": "^5.0.3",
+				"selderee": "^0.11.0"
+			},
+			"funding": {
+				"url": "https://ko-fi.com/killymxi"
+			}
 		},
 		"node_modules/@standard-schema/spec": {
 			"version": "1.1.0",
@@ -5634,6 +5666,59 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/dom-serializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+			}
+		},
+		"node_modules/dom-serializer/node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
 		"node_modules/dompurify": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
@@ -5641,6 +5726,20 @@
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
+			}
+		},
+		"node_modules/domutils": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+			"integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domutils?sponsor=1"
 			}
 		},
 		"node_modules/dunder-proto": {
@@ -6940,6 +7039,53 @@
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
+		"node_modules/html-to-text": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+			"integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+			"license": "MIT",
+			"dependencies": {
+				"@selderee/plugin-htmlparser2": "^0.11.0",
+				"deepmerge": "^4.3.1",
+				"dom-serializer": "^2.0.0",
+				"htmlparser2": "^8.0.2",
+				"selderee": "^0.11.0"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/htmlparser2": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+			"integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+			"funding": [
+				"https://github.com/fb55/htmlparser2?sponsor=1",
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.0.1",
+				"entities": "^4.4.0"
+			}
+		},
+		"node_modules/htmlparser2/node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
 		"node_modules/http-proxy-agent": {
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -7774,6 +7920,15 @@
 			},
 			"engines": {
 				"node": ">=0.10"
+			}
+		},
+		"node_modules/leac": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+			"integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://ko-fi.com/killymxi"
 			}
 		},
 		"node_modules/levn": {
@@ -8663,6 +8818,19 @@
 				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
 		},
+		"node_modules/parseley": {
+			"version": "0.12.1",
+			"resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+			"integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+			"license": "MIT",
+			"dependencies": {
+				"leac": "^0.6.0",
+				"peberminta": "^0.9.0"
+			},
+			"funding": {
+				"url": "https://ko-fi.com/killymxi"
+			}
+		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -8696,6 +8864,15 @@
 			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/peberminta": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+			"integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://ko-fi.com/killymxi"
+			}
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
@@ -8777,6 +8954,21 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/prettier": {
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+			"integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+			"license": "MIT",
+			"bin": {
+				"prettier": "bin/prettier.cjs"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
 			}
 		},
 		"node_modules/pretty-format": {
@@ -9088,6 +9280,21 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/react-promise-suspense": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/react-promise-suspense/-/react-promise-suspense-0.3.4.tgz",
+			"integrity": "sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^2.0.1"
+			}
+		},
+		"node_modules/react-promise-suspense/node_modules/fast-deep-equal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+			"integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+			"license": "MIT"
+		},
 		"node_modules/react-remove-scroll": {
 			"version": "2.7.2",
 			"resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
@@ -9222,6 +9429,18 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/resend": {
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/resend/-/resend-4.8.0.tgz",
+			"integrity": "sha512-R8eBOFQDO6dzRTDmaMEdpqrkmgSjPpVXt4nGfWsZdYOet0kqra0xgbvTES6HmCriZEXbmGk3e0DiGIaLFTFSHA==",
+			"license": "MIT",
+			"dependencies": {
+				"@react-email/render": "1.1.2"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/resolve": {
@@ -9419,6 +9638,18 @@
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
 			"integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
 			"license": "MIT"
+		},
+		"node_modules/selderee": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+			"integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+			"license": "MIT",
+			"dependencies": {
+				"parseley": "^0.12.0"
+			},
+			"funding": {
+				"url": "https://ko-fi.com/killymxi"
+			}
 		},
 		"node_modules/semver": {
 			"version": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"next-themes": "^0.4.6",
 		"react": "^19.2.4",
 		"react-dom": "^19.2.4",
+		"resend": "^4.8.0",
 		"server-only": "^0.0.1",
 		"stripe": "^20.4.1",
 		"tailwind-merge": "^3.5.0",

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,0 +1,70 @@
+import { Resend } from "resend";
+import { NextResponse } from "next/server";
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+export async function POST(request: Request) {
+	try {
+		const { name, email, message } = await request.json();
+
+		if (!name || !email || !message) {
+			return NextResponse.json({ success: false, error: "Missing required fields" }, { status: 400 });
+		}
+
+		// 1. Email to YOU (j.torres3.dev@gmail.com)
+		const { error: adminError } = await resend.emails.send({
+			from: "Contact Form <onboarding@resend.dev>",
+			to: "j.torres3.dev@gmail.com",
+			subject: `New Contact Message from ${name}`,
+			html: `
+                <div style="font-family: Arial, sans-serif; max-width: 600px; margin: auto; padding: 20px; border: 1px solid #e2e8f0; border-top: 4px solid #DAA520; border-radius: 8px; background: #ffffff; color: #1a202c;">
+                    <h2 style="color: #DAA520; margin-top: 0;">New Contact Message</h2>
+                    <p style="margin-bottom: 5px;"><strong>From:</strong> ${name}</p>
+                    <p style="margin-bottom: 15px;"><strong>Email:</strong> ${email}</p>
+                    <hr style="border: 0; border-top: 1px solid #e2e8f0; margin: 15px 0;" />
+                    <p style="font-weight: bold; margin-bottom: 5px;">Message:</p>
+                    <div style="background: #f7fafc; padding: 12px; border-radius: 6px; font-style: italic; color: #4a5568;">
+                        ${message.replace(/\n/g, "<br />")}
+                    </div>
+                </div>
+            `,
+		});
+
+		if (adminError) throw adminError;
+
+		// 2. Auto-Responder Email TO the Sender (visitor)
+		// NOTE: Sending to arbitrary emails requires a verified Domain on Resend.
+		// If using 'onboarding@resend.dev', this might only send to you or fails for others until verified.
+		const { error: autoError } = await resend.emails.send({
+			from: "Jesus Torres <onboarding@resend.dev>", // Or update once domain is verified
+			to: email,
+			subject: "Thanks for reaching out!",
+			html: `
+                <div style="font-family: Arial, sans-serif; max-width: 600px; margin: auto; padding: 20px; border: 1px solid #e2e8f0; border-top: 4px solid #DAA520; border-radius: 8px; background: #ffffff; color: #1a202c;">
+                    <h2 style="color: #DAA520; margin-top: 0;">Thanks for reaching out!</h2>
+                    <p>Hi <strong>${name}</strong>,</p>
+                    <p>We've received your message regarding: </p>
+                    <div style="background: #f7fafc; padding: 12px; border-radius: 6px; font-style: italic; color: #4a5568; margin-bottom: 15px;">
+                        "${message.replace(/\n/g, "<br />")}"
+                    </div>
+                    <p>I'll get back to you as soon as I can.</p>
+                    <hr style="border: 0; border-top: 1px solid #e2e8f0; margin: 15px 0;" />
+                    <p style="font-size: 14px; text-align: center; color: #a0aec0; margin-bottom: 0;">
+                        Best regards,<br />
+                        <strong>Jesus Torres</strong>
+                    </p>
+                </div>
+            `,
+		});
+
+		if (autoError) {
+			console.warn("Auto-responder failed (usually requires verified domain):", autoError);
+			// We don't throw error to avoid blocking the main contact alert to the user.
+		}
+
+		return NextResponse.json({ success: true });
+	} catch (e) {
+		console.error("Resend API Error:", e);
+		return NextResponse.json({ success: false, error: e }, { status: 500 });
+	}
+}

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,9 +1,8 @@
 import { Resend } from "resend";
 import { NextResponse } from "next/server";
 
-const resend = new Resend(process.env.RESEND_API_KEY);
-
 export async function POST(request: Request) {
+	const resend = new Resend(process.env.RESEND_API_KEY);
 	try {
 		const { name, email, message } = await request.json();
 

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -20,6 +20,7 @@ export default function ContactPage() {
 		setStatus("loading");
 
 		try {
+			// 1. Save to Supabase DB (Backup)
 			const { error } = await supabase
 				.from("contact_messages")
 				.insert([
@@ -27,6 +28,21 @@ export default function ContactPage() {
 				]);
 
 			if (error) throw error;
+
+			// 2. Trigger Resend Email API
+			const emailResponse = await fetch("/api/contact", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					name: formData.name,
+					email: formData.email,
+					message: formData.message
+				}),
+			});
+
+			if (!emailResponse.ok) {
+				console.warn("API Email response failed, but message saved to database.");
+			}
 
 			setStatus("success");
 			setFormData({ name: "", email: "", message: "" });


### PR DESCRIPTION
This pull request introduces email functionality for the contact form, allowing messages to be sent via the Resend service and providing an auto-responder to visitors. The implementation includes a new API route for handling email sending, updates to the contact page to trigger this API, and adds the required dependency.

**Contact form email integration:**

* Added the `resend` package to `package.json` to enable email sending capabilities.
* Created a new API route (`src/app/api/contact/route.ts`) that sends two emails: one notification to the site owner and an auto-response to the sender, including error handling and domain verification notes.

**Contact page enhancements:**

* Updated the contact page logic to trigger the new Resend email API after saving the message to the Supabase database, with appropriate error handling.
* Added a comment clarifying that messages are first saved to the Supabase database as a backup before triggering the email API.