### PR TITLE
Fix/p0 security data

### DIFF
--- a/src/__tests__/lib/donations.test.ts
+++ b/src/__tests__/lib/donations.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { requireWebhookSecret } from '@/lib/donations'
+import { requireWebhookSecret } from '@/lib/webhook-secrets'
 
 describe('requireWebhookSecret', () => {
   const originalEnv = process.env.NODE_ENV

--- a/src/__tests__/lib/donations.test.ts
+++ b/src/__tests__/lib/donations.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { requireWebhookSecret } from '@/lib/donations'
+
+describe('requireWebhookSecret', () => {
+  const originalEnv = process.env.NODE_ENV
+
+  beforeEach(() => {
+    vi.stubEnv('NODE_ENV', originalEnv)
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('returns the secret when configured', () => {
+    expect(requireWebhookSecret('whsec_test', 'STRIPE_WEBHOOK_SECRET')).toBe(
+      'whsec_test'
+    )
+  })
+
+  it('rejects missing secret in production', () => {
+    vi.stubEnv('NODE_ENV', 'production')
+
+    const result = requireWebhookSecret(undefined, 'STRIPE_WEBHOOK_SECRET')
+
+    expect(result).toBeInstanceOf(Response)
+    expect((result as Response).status).toBe(500)
+  })
+
+  it('allows missing secret outside production', () => {
+    vi.stubEnv('NODE_ENV', 'development')
+
+    expect(requireWebhookSecret(undefined, 'STRIPE_WEBHOOK_SECRET')).toBe('')
+  })
+})

--- a/src/__tests__/lib/ugc-media-bucket.test.ts
+++ b/src/__tests__/lib/ugc-media-bucket.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+describe('UGC media bucket', () => {
+  it('uses the ugc-media bucket name', () => {
+    const source = readFileSync(
+      resolve(process.cwd(), 'src/lib/ugc/media.ts'),
+      'utf8'
+    )
+
+    expect(source).toContain("const BUCKET_NAME = 'ugc-media'")
+    expect(source).not.toContain("const BUCKET_NAME = 'ugc-main'")
+  })
+})

--- a/src/app/api/crypto-donation/webhook/route.ts
+++ b/src/app/api/crypto-donation/webhook/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import crypto from "crypto";
-import { recordDonation, requireWebhookSecret } from "@/lib/donations";
+import { recordDonation } from "@/lib/donations";
+import { requireWebhookSecret } from "@/lib/webhook-secrets";
 
 /**
  * Coinbase Commerce Webhook endpoint

--- a/src/app/api/crypto-donation/webhook/route.ts
+++ b/src/app/api/crypto-donation/webhook/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import crypto from "crypto";
+import { recordDonation, requireWebhookSecret } from "@/lib/donations";
 
 /**
  * Coinbase Commerce Webhook endpoint
@@ -23,19 +24,21 @@ export async function POST(req: Request) {
 		);
 	}
 
-	const webhookSecret = process.env.COINBASE_WEBHOOK_SECRET;
+	const secretResult = requireWebhookSecret(
+		process.env.COINBASE_WEBHOOK_SECRET,
+		"COINBASE_WEBHOOK_SECRET"
+	);
 
-	// If webhook secret is not configured, skip signature verification
-	if (!webhookSecret) {
-		console.warn(
-			"COINBASE_WEBHOOK_SECRET is not configured. Webhook signature verification is disabled."
-		);
+	if (secretResult instanceof Response) {
+		return secretResult;
+	}
+
+	if (!secretResult) {
 		return NextResponse.json({ received: true }, { status: 200 });
 	}
 
-	// Verify the webhook signature
 	const expectedSig = crypto
-		.createHmac("sha256", webhookSecret)
+		.createHmac("sha256", secretResult)
 		.update(body)
 		.digest("hex");
 
@@ -48,27 +51,50 @@ export async function POST(req: Request) {
 	}
 
 	try {
-		const event = JSON.parse(body);
-		const eventType = event?.event?.type;
+		const payload = JSON.parse(body);
+		const eventType = payload?.event?.type;
+		const eventId = payload?.id as string | undefined;
 
 		switch (eventType) {
 			case "charge:confirmed": {
-				const charge = event.event.data;
-				const amount = charge?.pricing?.local?.amount ?? "unknown";
-				const currency = charge?.pricing?.local?.currency ?? "USD";
+				const charge = payload.event.data;
+				const amount = charge?.pricing?.local?.amount ?? null;
+				const currency = charge?.pricing?.local?.currency ?? null;
 
-				console.log(
-					`✅ Crypto donation confirmed: $${amount} ${currency} (Charge: ${charge?.code})`
-				);
+				if (!eventId) {
+					return NextResponse.json(
+						{ error: "Missing event id" },
+						{ status: 400 }
+					);
+				}
 
-				// Future: Save donation to database, send thank-you email, etc.
+				try {
+					const { duplicate } = await recordDonation({
+						provider: "coinbase",
+						provider_event_id: eventId,
+						amount: amount !== null ? Number(amount) : null,
+						currency,
+						status: "confirmed",
+						email: charge?.metadata?.email ?? null,
+					});
+
+					if (!duplicate) {
+						console.log(
+							`Crypto donation recorded: $${amount ?? "unknown"} ${currency ?? "USD"} (Charge: ${charge?.code})`
+						);
+					}
+				} catch (err) {
+					console.error("Failed to persist Coinbase donation:", err);
+					return NextResponse.json(
+						{ error: "Failed to persist donation" },
+						{ status: 500 }
+					);
+				}
 				break;
 			}
 			case "charge:failed": {
-				const charge = event.event.data;
-				console.log(
-					`❌ Crypto donation failed (Charge: ${charge?.code})`
-				);
+				const charge = payload.event.data;
+				console.log(`Crypto donation failed (Charge: ${charge?.code})`);
 				break;
 			}
 			default:

--- a/src/app/api/stripe-payment/webhook/route.ts
+++ b/src/app/api/stripe-payment/webhook/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getStripe } from "../../../../lib/stripe";
+import { recordDonation, requireWebhookSecret } from "@/lib/donations";
 import Stripe from "stripe";
 
 /**
@@ -28,14 +29,16 @@ export async function POST(req: Request) {
 		);
 	}
 
-	const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+	const secretResult = requireWebhookSecret(
+		process.env.STRIPE_WEBHOOK_SECRET,
+		"STRIPE_WEBHOOK_SECRET"
+	);
 
-	// If webhook secret is not configured, skip signature verification
-	// This allows the endpoint to exist without blocking deployment
-	if (!webhookSecret) {
-		console.warn(
-			"STRIPE_WEBHOOK_SECRET is not configured. Webhook signature verification is disabled."
-		);
+	if (secretResult instanceof Response) {
+		return secretResult;
+	}
+
+	if (!secretResult) {
 		return NextResponse.json({ received: true }, { status: 200 });
 	}
 
@@ -43,7 +46,7 @@ export async function POST(req: Request) {
 
 	try {
 		const stripe = getStripe();
-		event = stripe.webhooks.constructEvent(body, sig, webhookSecret);
+		event = stripe.webhooks.constructEvent(body, sig, secretResult);
 	} catch (err) {
 		const message = err instanceof Error ? err.message : "Unknown error";
 		console.error(`Webhook signature verification failed: ${message}`);
@@ -53,23 +56,38 @@ export async function POST(req: Request) {
 		);
 	}
 
-	// Handle the event
 	switch (event.type) {
 		case "checkout.session.completed": {
 			const session = event.data.object as Stripe.Checkout.Session;
 			const amountTotal = session.amount_total
-				? (session.amount_total / 100).toFixed(2)
-				: "unknown";
+				? session.amount_total / 100
+				: null;
 
-			console.log(
-				`✅ Donation received: $${amountTotal} USD (Session: ${session.id})`
-			);
+			try {
+				const { duplicate } = await recordDonation({
+					provider: "stripe",
+					provider_event_id: event.id,
+					amount: amountTotal,
+					currency: session.currency ?? null,
+					status: session.payment_status ?? "completed",
+					email: session.customer_details?.email ?? null,
+				});
 
-			// Future: Save donation to database, send thank-you email, etc.
+				if (!duplicate) {
+					console.log(
+						`Donation recorded: $${amountTotal ?? "unknown"} ${session.currency ?? "USD"} (Session: ${session.id})`
+					);
+				}
+			} catch (err) {
+				console.error("Failed to persist Stripe donation:", err);
+				return NextResponse.json(
+					{ error: "Failed to persist donation" },
+					{ status: 500 }
+				);
+			}
 			break;
 		}
 		default:
-			// Unexpected event type — log but don't error
 			console.log(`Unhandled Stripe event type: ${event.type}`);
 	}
 

--- a/src/app/api/stripe-payment/webhook/route.ts
+++ b/src/app/api/stripe-payment/webhook/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getStripe } from "../../../../lib/stripe";
-import { recordDonation, requireWebhookSecret } from "@/lib/donations";
+import { recordDonation } from "@/lib/donations";
+import { requireWebhookSecret } from "@/lib/webhook-secrets";
 import Stripe from "stripe";
 
 /**

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -48,13 +48,20 @@ export default function ContactPage() {
 
 		try {
 			// 1. Save to Supabase DB (Backup)
+			const messageWithCompany = formData.company
+				? `Company: ${formData.company}\n\n${formData.message}`
+				: formData.message;
+
 			const { error } = await supabase
 				.from("contact_messages")
 				.insert([
 					{
 						name: formData.name,
 						email: formData.email,
-						message: `[Service: ${formData.service}] [Budget: ${formData.budget}] [Timeline: ${formData.timeline}] [Company: ${formData.company || "N/A"}]\n\n${formData.message}`,
+						message: messageWithCompany,
+						service: formData.service,
+						budget: formData.budget,
+						timeline: formData.timeline,
 					}
 				]);
 

--- a/src/lib/donations.ts
+++ b/src/lib/donations.ts
@@ -11,28 +11,6 @@ export type DonationRecord = {
   email?: string | null
 }
 
-export function requireWebhookSecret(
-  secret: string | undefined,
-  envName: string
-): string | Response {
-  if (secret) {
-    return secret
-  }
-
-  if (process.env.NODE_ENV === 'production') {
-    console.error(`${envName} is not configured in production`)
-    return new Response(
-      JSON.stringify({ error: 'Webhook signing secret is not configured' }),
-      { status: 500, headers: { 'Content-Type': 'application/json' } }
-    )
-  }
-
-  console.warn(
-    `${envName} is not configured. Webhook signature verification is disabled.`
-  )
-  return ''
-}
-
 export async function recordDonation(
   donation: DonationRecord
 ): Promise<{ duplicate: boolean }> {

--- a/src/lib/donations.ts
+++ b/src/lib/donations.ts
@@ -1,0 +1,53 @@
+import 'server-only'
+
+import { createServiceClient } from '@/utils/supabase/service'
+
+export type DonationRecord = {
+  provider: string
+  provider_event_id: string
+  amount?: number | null
+  currency?: string | null
+  status?: string | null
+  email?: string | null
+}
+
+export function requireWebhookSecret(
+  secret: string | undefined,
+  envName: string
+): string | Response {
+  if (secret) {
+    return secret
+  }
+
+  if (process.env.NODE_ENV === 'production') {
+    console.error(`${envName} is not configured in production`)
+    return new Response(
+      JSON.stringify({ error: 'Webhook signing secret is not configured' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    )
+  }
+
+  console.warn(
+    `${envName} is not configured. Webhook signature verification is disabled.`
+  )
+  return ''
+}
+
+export async function recordDonation(
+  donation: DonationRecord
+): Promise<{ duplicate: boolean }> {
+  const supabase = createServiceClient()
+
+  const { error } = await supabase.from('donations').insert(donation)
+
+  if (error?.code === '23505') {
+    return { duplicate: true }
+  }
+
+  if (error) {
+    console.error('Failed to record donation:', error)
+    throw new Error('Failed to persist donation')
+  }
+
+  return { duplicate: false }
+}

--- a/src/lib/ugc/media.ts
+++ b/src/lib/ugc/media.ts
@@ -31,7 +31,7 @@ import type { ActionResult } from './posts'
 // Constants
 // =============================================================================
 
-const BUCKET_NAME = 'ugc-main'
+const BUCKET_NAME = 'ugc-media'
 const SIGNED_URL_EXPIRY = 60 // seconds (1 minute to complete upload)
 
 // =============================================================================

--- a/src/lib/webhook-secrets.ts
+++ b/src/lib/webhook-secrets.ts
@@ -1,0 +1,21 @@
+export function requireWebhookSecret(
+  secret: string | undefined,
+  envName: string
+): string | Response {
+  if (secret) {
+    return secret
+  }
+
+  if (process.env.NODE_ENV === 'production') {
+    console.error(`${envName} is not configured in production`)
+    return new Response(
+      JSON.stringify({ error: 'Webhook signing secret is not configured' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    )
+  }
+
+  console.warn(
+    `${envName} is not configured. Webhook signature verification is disabled.`
+  )
+  return ''
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,7 @@
 import { type NextRequest } from 'next/server'
 import { updateSession } from '@/utils/supabase/middleware'
 
-export async function proxy(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   return await updateSession(request)
 }
 

--- a/src/utils/supabase/middleware.ts
+++ b/src/utils/supabase/middleware.ts
@@ -37,16 +37,16 @@ export async function updateSession(request: NextRequest) {
   // Define public routes that don't require authentication
   // This allows SEO crawlers to index content and improves first-time visitor UX
   const publicPaths = [
-    '/',           // Home page
-    '/posts',      // Public posts feed
-    '/guides',     // Public documentation
-    '/about',      // About page
-    '/contact',    // Contact page
-    '/support',    // Support page
-    '/login',      // Login page
-
-    '/auth',       // Auth callbacks
-    '/api',        // API routes (they handle their own auth)
+    '/',
+    '/profile',
+    '/services',
+    '/studio',
+    '/posts',
+    '/contact',
+    '/support',
+    '/login',
+    '/auth',
+    '/api',
   ]
 
   const isPublicPath = publicPaths.some(path =>

--- a/src/utils/supabase/service.ts
+++ b/src/utils/supabase/service.ts
@@ -1,0 +1,19 @@
+import 'server-only'
+
+import { createClient } from '@supabase/supabase-js'
+
+export function createServiceClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!url || !key) {
+    throw new Error('Missing Supabase service role configuration')
+  }
+
+  return createClient(url, key, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  })
+}

--- a/supabase/migrations/005_contact_messages.sql
+++ b/supabase/migrations/005_contact_messages.sql
@@ -1,0 +1,21 @@
+-- Migration: Contact form submissions
+-- Stores inbound contact messages; anonymous users may INSERT only.
+
+CREATE TABLE IF NOT EXISTS public.contact_messages (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  email TEXT NOT NULL,
+  message TEXT NOT NULL,
+  service TEXT,
+  budget TEXT,
+  timeline TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+ALTER TABLE public.contact_messages ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Anyone can submit contact messages"
+  ON public.contact_messages
+  FOR INSERT
+  TO anon, authenticated
+  WITH CHECK (true);

--- a/supabase/migrations/006_donations.sql
+++ b/supabase/migrations/006_donations.sql
@@ -1,0 +1,16 @@
+-- Migration: Donation webhook records
+-- Persists verified Stripe and Coinbase donation events (service-role writes only).
+
+CREATE TABLE IF NOT EXISTS public.donations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  provider TEXT NOT NULL,
+  provider_event_id TEXT NOT NULL,
+  amount NUMERIC,
+  currency TEXT,
+  status TEXT,
+  email TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (provider, provider_event_id)
+);
+
+ALTER TABLE public.donations ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary
Sprint 01 Epic A: the four P0 security and data fixes, on one branch.

- **#79** Enable auth route protection by renaming `proxy.ts` to `middleware.ts` and updating the public-route allowlist (removed stale `/guides`, `/about`).
- **#80** Fix storage bucket name mismatch (`ugc-main` to `ugc-media`).
- **#81** Add `contact_messages` migration (anonymous INSERT-only RLS) and align the contact form schema (service, budget, timeline as columns).
- **#82** Persist verified Stripe and Coinbase donation webhooks to a new `donations` table with idempotency (`UNIQUE (provider, provider_event_id)`) and fail-closed secret enforcement in production.

Closes #79
Closes #80
Closes #81
Closes #82

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (18 tests)
- [ ] Logged-out `/settings` and `/editor/new` redirect to `/login`
- [ ] Logged-out `/profile`, `/services`, `/studio` render without redirect
- [ ] Apply migrations `005_contact_messages.sql` and `006_donations.sql` in Supabase; set `SUPABASE_SERVICE_ROLE_KEY`
- [ ] Contact form submission inserts one row; anonymous SELECT on `contact_messages` is denied
- [ ] Stripe test webhook creates one `donations` row; replay is idempotent (no duplicate, no 500)
- [ ] Coinbase test webhook creates one `donations` row; replay is idempotent
- [ ] Production webhooks reject requests when signing secrets are missing

## Notes
- Build emits a Next 16 deprecation warning: the `middleware.ts` convention is deprecated in favor of `proxy.ts`. Protection still runs (registered as "Proxy (Middleware)"). Tracked as a follow-up to migrate conventions cleanly.
- Confirm `recordDonation` treats a duplicate event as success (onConflict do-nothing / upsert), not a throwing insert, before relying on webhook idempotency.