### PR TITLE
fix: image icon tech stack rendering for user profile

### DIFF
--- a/src/lib/allowedImageHosts.ts
+++ b/src/lib/allowedImageHosts.ts
@@ -12,6 +12,9 @@ export const ALLOWED_IMAGE_HOSTS = [
 	"rtyyywzpdoroqouvskop.supabase.co",
 	"lh3.googleusercontent.com",
 	"*.googleusercontent.com",
+	// Tech stack icon CDNs
+	"cdn.jsdelivr.net",
+	"cdn.simpleicons.org",
 ] as const
 
 export const IMAGE_REMOTE_PATTERNS = [
@@ -24,6 +27,9 @@ export const IMAGE_REMOTE_PATTERNS = [
 	{ protocol: "https" as const, hostname: "rtyyywzpdoroqouvskop.supabase.co" },
 	{ protocol: "https" as const, hostname: "lh3.googleusercontent.com" },
 	{ protocol: "https" as const, hostname: "*.googleusercontent.com" },
+	// Tech stack icon CDNs
+	{ protocol: "https" as const, hostname: "cdn.jsdelivr.net" },
+	{ protocol: "https" as const, hostname: "cdn.simpleicons.org" },
 ]
 
 /** CSP img-src host entries derived from ALLOWED_IMAGE_HOSTS (excludes wildcards). */


### PR DESCRIPTION
This pull request updates the list of allowed image hosts to support additional CDNs used for tech stack icons. The main change is adding `cdn.jsdelivr.net` and `cdn.simpleicons.org` to both the `ALLOWED_IMAGE_HOSTS` and `IMAGE_REMOTE_PATTERNS` arrays.

Image host configuration updates:

* Added `cdn.jsdelivr.net` and `cdn.simpleicons.org` to the `ALLOWED_IMAGE_HOSTS` array in `src/lib/allowedImageHosts.ts` to permit images from these CDNs.
* Added corresponding entries for `cdn.jsdelivr.net` and `cdn.simpleicons.org` in the `IMAGE_REMOTE_PATTERNS` array to allow remote images from these sources.