### PR TITLE
fix: use verified domain sender for contact emails

### DIFF
--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -59,7 +59,7 @@ export async function POST(request: Request) {
 
 		// 1. Email to YOU (j.torres3.dev@gmail.com)
 		const { error: adminError } = await resend.emails.send({
-			from: "Contact Form <onboarding@resend.dev>",
+			from: "Contact Form <contact@jt-devstudio.tech>",
 			to: "j.torres3.dev@gmail.com",
 			replyTo: email,
 			subject: `New Contact Message from ${name}`,
@@ -83,7 +83,7 @@ export async function POST(request: Request) {
 		// NOTE: Sending to arbitrary emails requires a verified Domain on Resend.
 		// If using 'onboarding@resend.dev', this might only send to you or fails for others until verified.
 		const { error: autoError } = await resend.emails.send({
-			from: "Jesus Torres <onboarding@resend.dev>", // Or update once domain is verified
+			from: "Jesus Torres <contact@jt-devstudio.tech>",
 			to: email,
 			subject: "Thanks for reaching out!",
 			html: `


### PR DESCRIPTION
This pull request updates the sender email addresses used in outgoing messages from the contact form API to use a custom domain, improving professionalism and deliverability.

**Email sender updates:**

* Changed the `from` address for admin notification emails to use `contact@jt-devstudio.tech` instead of the default Resend onboarding address in `src/app/api/contact/route.ts`.
* Updated the `from` address for auto-reply emails sent to users to also use `contact@jt-devstudio.tech` in `src/app/api/contact/route.ts`.