### PR TITLE
feat: gated resume download with auth + download tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ next-env.d.ts
 # mynotes folder
 /mynotes
 .claude
+
+# dev-projects (local strategy, prompts, notes — never push to GitHub)
+/dev-projects

--- a/src/app/api/resume/download/route.ts
+++ b/src/app/api/resume/download/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/utils/supabase/server";
+
+const BUCKET = "resume";
+const FILE_PATH = "Resume_JesusTorres.pdf";
+const SIGNED_URL_EXPIRY = 60; // seconds — short-lived for security
+
+export async function GET(request: Request) {
+  const supabase = await createClient();
+
+  // 1. Verify auth server-side
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return NextResponse.json(
+      { error: "Unauthorized. Please sign in to download the resume." },
+      { status: 401 }
+    );
+  }
+
+  // 2. Generate short-lived signed URL from private bucket
+  const { data: signedData, error: signedError } = await supabase.storage
+    .from(BUCKET)
+    .createSignedUrl(FILE_PATH, SIGNED_URL_EXPIRY, {
+      download: "Resume_JesusTorres.pdf",
+    });
+
+  if (signedError || !signedData?.signedUrl) {
+    console.error("Supabase signed URL error:", signedError);
+    return NextResponse.json(
+      { error: "Failed to generate download link. Please try again." },
+      { status: 500 }
+    );
+  }
+
+  // 3. Log the download (non-blocking — don't let a log failure block the download)
+  const ip =
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    request.headers.get("x-real-ip") ??
+    "unknown";
+
+  supabase
+    .from("resume_downloads")
+    .insert({
+      user_id: user.id,
+      user_email: user.email,
+      ip_address: ip,
+    })
+    .then(({ error }) => {
+      if (error) console.warn("Resume download log failed:", error.message);
+    });
+
+  // 4. Return the signed URL
+  return NextResponse.json({ url: signedData.signedUrl });
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -4,9 +4,10 @@ import { getGitHubProfile, getTopReposByStars } from "../services/github";
 import { env } from "@/lib/env";
 import Image from "next/image";
 import Link from "next/link";
-import { Github, Globe, FileText, Star, GitFork, Mail, ExternalLink, Shield, Briefcase, GraduationCap } from "lucide-react";
+import { Github, Globe, Star, GitFork, Mail, ExternalLink, Shield, Briefcase, GraduationCap } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { TechStackDisplay } from "@/components/tech-stack";
+import { ResumeDownloadButton } from "@/components/profile/ResumeDownloadButton";
 
 type GithubProfile = {
 	avatar_url: string;
@@ -155,12 +156,7 @@ export default async function ProfilePage() {
 							</Link>
 						)}
 
-						<Button asChild size="sm" className="bg-[#DAA520] hover:bg-[#DAA520]/80 text-black font-bold h-10 px-4 rounded-xl">
-							<Link href="/resume.pdf" target="_blank" rel="noopener noreferrer">
-								<FileText className="w-4 h-4 mr-2" />
-								Resume
-							</Link>
-						</Button>
+						<ResumeDownloadButton />
 
 						<Button asChild size="sm" variant="outline" className="h-10 px-4 rounded-xl border-[#DAA520]/30 text-[#DAA520] hover:bg-[#DAA520]/10">
 							<Link href="/contact">

--- a/src/components/profile/ResumeDownloadButton.tsx
+++ b/src/components/profile/ResumeDownloadButton.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState } from "react";
+import { FileText, Download, Loader2, Lock } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { useAuth } from "@/context/AuthContext";
+
+export function ResumeDownloadButton() {
+  const { user, loading, hasMounted } = useAuth();
+  const [downloading, setDownloading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isLoggedIn = hasMounted && !loading && !!user;
+
+  const handleDownload = async () => {
+    if (!isLoggedIn) return;
+    setDownloading(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/resume/download");
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || "Download failed");
+      }
+      const { url } = await res.json();
+
+      // Trigger download without navigating away
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "Resume_JesusTorres.pdf";
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  // While auth is loading, show a neutral disabled state
+  if (!hasMounted || loading) {
+    return (
+      <Button
+        disabled
+        size="sm"
+        className="bg-[#DAA520] hover:bg-[#DAA520]/80 text-black font-bold h-10 px-4 rounded-xl opacity-60"
+      >
+        <FileText className="w-4 h-4 mr-2" />
+        Resume
+      </Button>
+    );
+  }
+
+  // Logged out — disabled button with tooltip
+  if (!isLoggedIn) {
+    return (
+      <TooltipProvider delayDuration={200}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-block cursor-not-allowed">
+              <Button
+                disabled
+                size="sm"
+                className="bg-[#DAA520]/40 text-black/60 font-bold h-10 px-4 rounded-xl pointer-events-none"
+              >
+                <Lock className="w-4 h-4 mr-2" />
+                Resume
+              </Button>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" className="text-xs">
+            Sign in to download resume
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
+  // Logged in — active download button
+  return (
+    <div className="flex flex-col items-start gap-1">
+      <Button
+        onClick={handleDownload}
+        disabled={downloading}
+        size="sm"
+        className="bg-[#DAA520] hover:bg-[#DAA520]/80 text-black font-bold h-10 px-4 rounded-xl"
+      >
+        {downloading ? (
+          <>
+            <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+            Downloading...
+          </>
+        ) : (
+          <>
+            <Download className="w-4 h-4 mr-2" />
+            Resume
+          </>
+        )}
+      </Button>
+      {error && (
+        <p className="text-xs text-red-500">{error}</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
This pull request implements a secure, authenticated resume download feature. The main change is replacing the previous public resume download link with a protected flow that requires users to sign in before accessing the file. The implementation includes both backend API logic to generate short-lived signed URLs and a new frontend button component that handles authentication states, download logic, and error feedback.

**Backend: Secure Resume Download API**

- Adds a new API route (`src/app/api/resume/download/route.ts`) that:
  - Authenticates the user server-side before allowing download.
  - Generates a short-lived signed URL from a private Supabase storage bucket for the resume file.
  - Logs each download attempt with user and IP info (non-blocking).
  - Returns the signed URL as a JSON response.

**Frontend: Authenticated Resume Download Button**

- Introduces a new `ResumeDownloadButton` component (`src/components/profile/ResumeDownloadButton.tsx`) that:
  - Displays different UI states based on authentication (loading, logged out with tooltip, logged in and active).
  - Handles download logic by calling the new API, triggering the file download, and showing errors if any occur.
  - Uses icons and tooltips to improve UX.

**Integration and UI Updates**

- Replaces the old public resume download `<Button>` with the new `ResumeDownloadButton` in the profile page (`src/app/profile/page.tsx`), ensuring only authenticated users can download the resume.
- Removes the unused `FileText` icon import from the profile page as it's now handled within the new button component.