### PR TITLE
feat: add JSON-LD structured data and founder attribution for SEO entity disambiguation

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { LayoutContent } from "../components/layout/LayoutContent";
 import { AuthProvider } from "@/context/AuthContext";
 import { CookieConsent } from "@/components/CookieConsent";
 import { ConsentAwareAnalytics } from "@/components/ConsentAwareAnalytics";
+import { JsonLd } from "@/components/JsonLd";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -20,6 +21,7 @@ export default function RootLayout({
 	return (
 		<html lang="en" suppressHydrationWarning>
 			<body className={inter.className} suppressHydrationWarning>
+				<JsonLd />
 				<AuthProvider>
 					<ThemeProvider
 						enableSystem

--- a/src/components/JsonLd.tsx
+++ b/src/components/JsonLd.tsx
@@ -1,0 +1,49 @@
+// Structured data (schema.org JSON-LD) so search engines and AI systems can
+// unambiguously identify this business and its founder, distinct from any
+// unrelated same-named entities elsewhere on the web.
+export function JsonLd() {
+	const schema = {
+		"@context": "https://schema.org",
+		"@graph": [
+			{
+				"@type": "ProfessionalService",
+				"@id": "https://jt-devstudio.tech/#organization",
+				name: "JT Dev Studio",
+				url: "https://jt-devstudio.tech",
+				description:
+					"Freelance web development, original SaaS products, and technology services by Jesus Torres, based in Amarillo, Texas.",
+				founder: { "@id": "https://jt-devstudio.tech/#founder" },
+				address: {
+					"@type": "PostalAddress",
+					addressLocality: "Amarillo",
+					addressRegion: "TX",
+					addressCountry: "US",
+				},
+				sameAs: [
+					"https://github.com/TorresjDev",
+					"https://linkedin.com/in/torresjdev",
+				],
+			},
+			{
+				"@type": "Person",
+				"@id": "https://jt-devstudio.tech/#founder",
+				name: "Jesus Torres",
+				jobTitle: "Founder & Software Engineer",
+				url: "https://jt-devstudio.tech/profile",
+				worksFor: { "@id": "https://jt-devstudio.tech/#organization" },
+				sameAs: [
+					"https://github.com/TorresjDev",
+					"https://linkedin.com/in/torresjdev",
+				],
+			},
+		],
+	};
+
+	return (
+		<script
+			type="application/ld+json"
+			// eslint-disable-next-line react/no-danger
+			dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+		/>
+	);
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -16,6 +16,9 @@ const Footer = () => {
 						Studio — building tools, apps, and experiences that solve real
 						problems.
 					</p>
+					<p className="mt-2 text-sm text-[#C0C0C0]/70">
+						Founded and built by Jesus Torres.
+					</p>
 				</div>
 
 				{/* Navigation */}


### PR DESCRIPTION
This pull request adds structured data to the application to improve search engine and AI understanding of the business and its founder, and makes a minor improvement to the site footer. The most important changes are:

**SEO and discoverability improvements:**

* Added a new `JsonLd` component that injects schema.org JSON-LD structured data describing the business ("JT Dev Studio") and its founder ("Jesus Torres") for better search engine and AI recognition.
* Imported and rendered the new `JsonLd` component in the root layout (`src/app/layout.tsx`) so that structured data is present on every page. [[1]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R10) [[2]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R24)

**UI/content update:**

* Updated the footer to explicitly state that the site was founded and built by Jesus Torres.